### PR TITLE
Add universal friend simulation mod

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.19)
+project(friendgd)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_library(${PROJECT_NAME} SHARED
+    src/main.cpp
+    src/FriendSimulation.cpp
+)
+
+target_include_directories(${PROJECT_NAME}
+    PRIVATE
+    ${GEODE_SDK_PATH}/bindings
+)
+
+target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+    geode-sdk
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# friendgd
+# FriendGD
+
+Universal Friendship is a Geode mod for Geometry Dash that pretends every user is on your friend list. When you open a profile you will always see the messaging and friendship controls as if you were already connected.
+
+## Features
+
+- Hooks the internal friendship checks so any profile is treated as a friend.
+- Forces the message and block buttons to render as they would for existing friends.
+- Keeps the original backend messaging flow while skipping the "friends only" requirement.
+- Includes a Geode setting toggle to enable/disable the simulation and an optional partial mode that only spoofs non-friends.
+- Logs recoverable errors encountered while patching the profile UI, helping diagnose conflicts with other mods.
+
+## Building
+
+This project follows the standard [Geode](https://github.com/geode-sdk/geode) CMake layout. Make sure the `GEODE_SDK_PATH` environment variable points to your Geode SDK folder before configuring the project.
+
+```bash
+cmake -B build
+cmake --build build
+```
+
+Then place the generated `.geode` package in your Geometry Dash mods folder.

--- a/mod.json
+++ b/mod.json
@@ -1,0 +1,34 @@
+{
+  "geode": "2.0.0",
+  "version": "1.0.0",
+  "id": "com.friendgd.everyone",
+  "name": "Universal Friendship",
+  "developers": ["AI Assistant"],
+  "description": "Marks every Geometry Dash profile as a friend, unlocking messaging and friend interactions without touching the real list.",
+  "dependencies": [
+    {
+      "id": "geode.loader",
+      "version": ">=2.0.0"
+    }
+  ],
+  "settings": {
+    "enable-simulation": {
+      "name": "Enable universal friendship",
+      "description": "When enabled, every profile is treated as if it is already in your friend list.",
+      "type": "bool",
+      "default": true
+    },
+    "partial-mode": {
+      "name": "Simulate only for non-friends",
+      "description": "Apply the simulation only to players that are not already part of the real friend list.",
+      "type": "bool",
+      "default": false
+    },
+    "log-errors": {
+      "name": "Log profile warnings",
+      "description": "If an unexpected error occurs while patching profile UI elements, the mod will log it to the Geode console.",
+      "type": "bool",
+      "default": true
+    }
+  }
+}

--- a/src/FriendSimulation.cpp
+++ b/src/FriendSimulation.cpp
@@ -1,0 +1,164 @@
+#include "FriendSimulation.hpp"
+
+#include <Geode/binding/CCMenuItemSpriteExtra.hpp>
+#include <Geode/binding/GJFriendRequest.hpp>
+#include <Geode/binding/GJProfilePage.hpp>
+#include <Geode/binding/GJUserScore.hpp>
+#include <Geode/modify/GJAccountManager.hpp>
+#include <Geode/modify/GJMessagePopup.hpp>
+#include <Geode/modify/GJProfilePage.hpp>
+
+using namespace geode::prelude;
+
+namespace friendgd {
+    bool isSimulationEnabled() {
+        return Mod::get()->getSettingValue<bool>(kEnableSetting);
+    }
+
+    bool isPartialModeEnabled() {
+        return Mod::get()->getSettingValue<bool>(kPartialSetting);
+    }
+
+    bool shouldLogErrors() {
+        return Mod::get()->getSettingValue<bool>(kLogSetting);
+    }
+
+    bool shouldSpoofFriend(bool originalValue) {
+        if (!isSimulationEnabled()) {
+            return originalValue;
+        }
+        if (isPartialModeEnabled() && originalValue) {
+            return originalValue;
+        }
+        return true;
+    }
+
+    bool shouldSpoofMessageAccess(bool originalValue) {
+        if (!isSimulationEnabled()) {
+            return originalValue;
+        }
+        if (isPartialModeEnabled() && originalValue) {
+            return originalValue;
+        }
+        return true;
+    }
+}
+
+namespace {
+    constexpr FriendRequestStatus kFriendsStatus = FriendRequestStatus::Accepted;
+
+    void activateFriendUI(GJProfilePage* page) {
+        if (!page) {
+            return;
+        }
+
+        auto manager = GJAccountManager::sharedState();
+        if (!manager) {
+            if (friendgd::shouldLogErrors()) {
+                log::error("[FriendGD] Missing account manager when updating profile UI.");
+            }
+            return;
+        }
+
+        const int accountID = page->m_score ? page->m_score->m_accountID : 0;
+        const bool realFriend = manager->GJAccountManager::isFriend(accountID);
+
+        if (!friendgd::isSimulationEnabled()) {
+            return;
+        }
+
+        if (friendgd::isPartialModeEnabled() && realFriend) {
+            return;
+        }
+
+        page->m_isFriend = true;
+        page->m_friendStatus = kFriendsStatus;
+
+        if (page->m_messageBtn) {
+            page->m_messageBtn->setVisible(true);
+            page->m_messageBtn->setEnabled(true);
+        }
+
+        if (page->m_sendRequestBtn) {
+            page->m_sendRequestBtn->setVisible(false);
+            page->m_sendRequestBtn->setEnabled(false);
+        }
+
+        if (page->m_toggleBlockBtn) {
+            page->m_toggleBlockBtn->setEnabled(true);
+        }
+    }
+}
+
+class $modify(FriendAccountManager, GJAccountManager) {
+public:
+    bool isFriend(int accountID) {
+        bool original = GJAccountManager::isFriend(accountID);
+        return friendgd::shouldSpoofFriend(original);
+    }
+
+    bool isFriendRequestSent(int accountID) {
+        bool original = GJAccountManager::isFriendRequestSent(accountID);
+        if (!friendgd::isSimulationEnabled()) {
+            return original;
+        }
+        if (friendgd::isPartialModeEnabled() && original) {
+            return original;
+        }
+        return false;
+    }
+
+    FriendRequestStatus friendRequestStatusForUser(int accountID) {
+        auto status = GJAccountManager::friendRequestStatusForUser(accountID);
+        if (!friendgd::isSimulationEnabled()) {
+            return status;
+        }
+        if (friendgd::isPartialModeEnabled() && status == kFriendsStatus) {
+            return status;
+        }
+        return kFriendsStatus;
+    }
+
+    bool canSendMessageToUser(int accountID) {
+        bool original = GJAccountManager::canSendMessageToUser(accountID);
+        return friendgd::shouldSpoofMessageAccess(original);
+    }
+};
+
+class $modify(FriendProfilePage, GJProfilePage) {
+public:
+    void updateUserScore() {
+        GJProfilePage::updateUserScore();
+        friendgd::withErrorLogging("updateUserScore", [this] {
+            activateFriendUI(this);
+            return 0;
+        });
+    }
+
+    void setupButtons() {
+        GJProfilePage::setupButtons();
+        friendgd::withErrorLogging("setupButtons", [this] {
+            activateFriendUI(this);
+            return 0;
+        });
+    }
+};
+
+class $modify(FriendMessagePopup, GJMessagePopup) {
+public:
+    bool init(GJUserMessage* message, GJMessagePopupDelegate* delegate) {
+        if (!GJMessagePopup::init(message, delegate)) {
+            return false;
+        }
+
+        if (friendgd::isSimulationEnabled()) {
+            if (m_buttonMenu) {
+                if (auto sendBtn = static_cast<CCMenuItemSpriteExtra*>(m_buttonMenu->getChildByTag(1))) {
+                    sendBtn->setVisible(true);
+                    sendBtn->setEnabled(true);
+                }
+            }
+        }
+        return true;
+    }
+};

--- a/src/FriendSimulation.hpp
+++ b/src/FriendSimulation.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <Geode/Geode.hpp>
+
+namespace friendgd {
+    inline constexpr const char* kEnableSetting = "enable-simulation";
+    inline constexpr const char* kPartialSetting = "partial-mode";
+    inline constexpr const char* kLogSetting = "log-errors";
+
+    bool isSimulationEnabled();
+    bool isPartialModeEnabled();
+    bool shouldLogErrors();
+
+    bool shouldSpoofFriend(bool originalValue);
+    bool shouldSpoofMessageAccess(bool originalValue);
+
+    template <class Fn>
+    auto withErrorLogging(const char* context, Fn&& fn) -> decltype(fn()) {
+        try {
+            return fn();
+        }
+        catch (const std::exception& err) {
+            if (shouldLogErrors()) {
+                geode::log::error("[FriendGD] {}: {}", context, err.what());
+            }
+            throw;
+        }
+    }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,13 @@
+#include <Geode/Geode.hpp>
+#include <Geode/loader/Mod.hpp>
+
+using namespace geode::prelude;
+
+GEODE_MOD_REGISTER();
+
+class FriendGDMod final : public Mod {
+protected:
+    void onLoad() override {
+        log::info("FriendGD loaded: everyone is now a friend!");
+    }
+};


### PR DESCRIPTION
## Summary
- add mod metadata, build setup, and a minimal loader entry point
- hook Geometry Dash friendship and profile UI logic to force every profile to appear as a friend
- provide toggles for enabling the simulation, partial spoofing, and logging unexpected profile issues

## Testing
- not run (environment only provides source changes)

------
https://chatgpt.com/codex/tasks/task_e_68d5ba1f46588331bd17f5ab13f94e65