### PR TITLE
Improve Geode SDK detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,20 @@ project(friendgd)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if(NOT DEFINED GEODE_SDK_PATH AND DEFINED ENV{GEODE_SDK_PATH})
+    set(GEODE_SDK_PATH "$ENV{GEODE_SDK_PATH}")
+endif()
+
+if(NOT GEODE_SDK_PATH)
+    message(FATAL_ERROR "GEODE_SDK_PATH is not set. Set the variable or install the SDK with 'geode setup sdk'.")
+endif()
+
+if(NOT EXISTS "${GEODE_SDK_PATH}/cmake/Geode.cmake")
+    message(FATAL_ERROR "Could not find Geode SDK CMake helpers in ${GEODE_SDK_PATH}. Make sure the SDK is installed correctly.")
+endif()
+
+include("${GEODE_SDK_PATH}/cmake/Geode.cmake")
+
 add_library(${PROJECT_NAME} SHARED
     src/main.cpp
     src/FriendSimulation.cpp
@@ -13,6 +27,8 @@ target_include_directories(${PROJECT_NAME}
     PRIVATE
     ${GEODE_SDK_PATH}/bindings
 )
+
+setup_geode_mod(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME}
     PRIVATE

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Universal Friendship is a Geode mod for Geometry Dash that pretends every user i
 
 ## Building
 
-This project follows the standard [Geode](https://github.com/geode-sdk/geode) CMake layout. Make sure the `GEODE_SDK_PATH` environment variable points to your Geode SDK folder before configuring the project.
+This project follows the standard [Geode](https://github.com/geode-sdk/geode) CMake layout. Install the SDK with the Geode CLI and make sure the `GEODE_SDK_PATH` environment variable points to your Geode SDK folder (the CLI command `geode setup sdk` will do both).
 
 ```bash
 cmake -B build


### PR DESCRIPTION
## Summary
- detect the Geode SDK path from the environment automatically during configuration
- validate the SDK installation before including the Geode CMake helpers and wire up `setup_geode_mod`
- clarify the README build instructions with the recommended `geode setup sdk` command

## Testing
- not run (environment does not provide the Geode SDK)


------
https://chatgpt.com/codex/tasks/task_e_68d5be2dd9f08331b53f2ad36783d68c