### PR TITLE
Fix mod registration to specify FriendGDMod

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,11 +3,11 @@
 
 using namespace geode::prelude;
 
-GEODE_MOD_REGISTER();
-
 class FriendGDMod final : public Mod {
 protected:
     void onLoad() override {
         log::info("FriendGD loaded: everyone is now a friend!");
     }
 };
+
+GEODE_MOD_REGISTER(FriendGDMod);


### PR DESCRIPTION
## Summary
- move the mod registration macro after the class definition
- register FriendGDMod explicitly to avoid missing type errors during build

## Testing
- cmake --build build *(fails: /workspace/friendgd/build is not a directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c4f70dd4833193c47fe3216705eb